### PR TITLE
Add section for VSCode "working sets" behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Inspired by: [xg2xg](https://github.com/jhuangtw-dev/xg2xg), [Venkat V Note (pri
 | Thrift | [GRPC](https://grpc.io/), [Thrift](https://github.com/apache/thrift) |
 | Unicorn         | [Rockset](https://rockset.com/) |
 | Unidash | [Grafana](https://www.grafana.com/), [Metabase](https://www.metabase.com/) | [Looker](https://looker.com/), [Tableau](https://www.tableau.com/) |
+| Working Set (VSCode Extention) | [Fildir](https://github.com/diggyk/fildir) | | An extension for VSCode that lets you filter out the directories in a monorepo you don't care about |
 | Workday | | [Workday](https://workday.com), [Charlie HR](https://www.charliehr.com/), [Hibob](https://www.hibob.com/) |
 | Workplace | | [HumHub](https://www.humhub.com/), [Basecamp](https://basecamp.com/), [Whaller](https://whaller.com/) |
 | ZippyDB | [Badger (Dgraph)](https://github.com/dgraph-io/badger) | [CockroachDB](https://www.cockroachlabs.com/) [Consul (Hashicorp)](https://www.consul.io/), [Etcd](https://www.etcd.io) | Key-Value stores based on Raft which scale horizontally. Cockroach is sharded. Consul provides service discovery. |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Inspired by: [xg2xg](https://github.com/jhuangtw-dev/xg2xg), [Venkat V Note (pri
 | Thrift | [GRPC](https://grpc.io/), [Thrift](https://github.com/apache/thrift) |
 | Unicorn         | [Rockset](https://rockset.com/) |
 | Unidash | [Grafana](https://www.grafana.com/), [Metabase](https://www.metabase.com/) | [Looker](https://looker.com/), [Tableau](https://www.tableau.com/) |
-| Working Set (VSCode Extention) | [Fildir](https://github.com/diggyk/fildir) | | An extension for VSCode that lets you filter out the directories in a monorepo you don't care about |
+| Working Set (VSCode Extention) | [Fildir](https://marketplace.visualstudio.com/items?itemName=diggyk.fildir), [Working Sets](https://marketplace.visualstudio.com/items?itemName=bernardop.working-sets) | | VSCode extensions to help you focus on specific files or directories in a monorepo |
 | Workday | | [Workday](https://workday.com), [Charlie HR](https://www.charliehr.com/), [Hibob](https://www.hibob.com/) |
 | Workplace | | [HumHub](https://www.humhub.com/), [Basecamp](https://basecamp.com/), [Whaller](https://whaller.com/) |
 | ZippyDB | [Badger (Dgraph)](https://github.com/dgraph-io/badger) | [CockroachDB](https://www.cockroachlabs.com/) [Consul (Hashicorp)](https://www.consul.io/), [Etcd](https://www.etcd.io) | Key-Value stores based on Raft which scale horizontally. Cockroach is sharded. Consul provides service discovery. |


### PR DESCRIPTION
Visual Studio Code had some extensions that were internal to FB. The one I really like and used the most was "working sets" which actually let you filter down the files/directories you actually wanted to see in `fbcode` so you didn't have to scroll for days down the giant list of everything.