### PR TITLE
Add RacksLab/RacksDB as an inventory solution alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Inspired by: [xg2xg](https://github.com/jhuangtw-dev/xg2xg), [Venkat V Note (pri
 | Scuba | [MemSQL](https://www.memsql.com/), [Snorkel](https://snorkel.logv.org/), [Superset+Druid](https://www.youtube.com/watch?v=W_Sp4jo1ACg) (yt), [LocustDB](https://github.com/cswinter/LocustDB), [InfluxDB+Grafana](https://grafana.com/docs/grafana/latest/features/datasources/influxdb/) | [Honeycomb](https://www.honeycomb.io/) (SaaS, exfb), [Interana](https://www.interana.com/), [Looker](https://looker.com/), [DBT](https://www.getdbt.com/) |
 | Scribe | [Apache Pulsar](https://pulsar.apache.org/), [Kafka](https://kafka.apache.org/), [Amazon Kinesis](https://aws.amazon.com/kinesis/) |
 | SEV Manager | [Kintaba](https://kintaba.com) | [Blameless](https://www.blameless.com), [FireHydrant](https://firehydrant.io/), [Grafana Incident](https://grafana.com/blog/2022/02/02/announcing-grafana-incident-smart-incident-management-for-your-teams/), [Pager Duty](https://www.pagerduty.com), [Incident](https://incident.io/)
-| SeRF | [Netbox](https://github.com/netbox-community/netbox), [Tinkerbell](https://github.com/tinkerbell/tink) | | Physical inventory and IPAM |
+| SeRF | [Netbox](https://github.com/netbox-community/netbox), [Tinkerbell](https://github.com/tinkerbell/tink), [RacksDB](https://rackslab.io/en/solutions/racksdb) | | Physical inventory and IPAM |
 | SI/Site Integrity | [Haxl](https://github.com/facebook/Haxl) |
 | Sitevar | [Consul.io](https://www.consul.io/), [Etcd](https://www.etcd.io)|
 | SRT (Single Review Tool) | | [LabelBox](https://labelbox.com/) |


### PR DESCRIPTION
A friend of mine is running a business and has an opensource inventory solution that might be worth adding as an alternative solution to SeRF.